### PR TITLE
out of forward object

### DIFF
--- a/libgst/heap.c
+++ b/libgst/heap.c
@@ -79,7 +79,7 @@ struct heap
    heap instead of the pointer to the base location available to
    clients.  */
 static PTR heap_sbrk_internal (struct heap *hdp,
-			       int size);
+			       size_t size);
 
 /* Cache pagesize-1 for the current host machine.  Note that if the
    host does not readily provide a getpagesize() function, we need to
@@ -100,7 +100,7 @@ extern int getpagesize ();
 
 
 heap
-_gst_heap_create (PTR address, int size)
+_gst_heap_create (PTR address, size_t size)
 {
   struct heap mtemp;
   struct heap *hdp;
@@ -189,7 +189,7 @@ _gst_heap_sbrk (heap hd,
 
 PTR
 heap_sbrk_internal (struct heap * hdp,
-		    int size)
+		    size_t size)
 {
   char *result = NULL;
   size_t mapbytes;		/* Number of bytes to map */

--- a/libgst/heap.h
+++ b/libgst/heap.h
@@ -64,7 +64,7 @@ typedef char *heap;
    implementation details.
 
    On failure returns NULL.  */
-extern heap _gst_heap_create (PTR address, int size) 
+extern heap _gst_heap_create (PTR address, size_t size)
   ATTRIBUTE_HIDDEN;
 
 /* Terminate access to a heap managed region by unmapping all memory pages

--- a/libgst/oop.c
+++ b/libgst/oop.c
@@ -197,7 +197,7 @@ static void scan_grey_objects ();
 static void scan_grey_pages ();
 
 /* Greys a page worth of pointers starting at BASE.  */
-static void add_to_grey_list (OOP *base, int n);
+static void add_to_grey_list (OOP *base, size_t n);
 
 /* Greys the object OOP.  */
 static void add_grey_object (OOP oop);
@@ -1608,7 +1608,7 @@ add_grey_object (OOP oop)
 {
   grey_area_node *entry;
   gst_object obj = OOP_TO_OBJ (oop);
-  int numFields = scanned_fields_in (obj, OOP_GET_FLAGS (oop));
+  size_t numFields = scanned_fields_in (obj, OOP_GET_FLAGS (oop));
   OOP *base = &(obj->objClass);
 
   if (!numFields)
@@ -1635,7 +1635,7 @@ add_grey_object (OOP oop)
 }
 
 void
-add_to_grey_list (OOP *base, int n)
+add_to_grey_list (OOP *base, size_t n)
 {
   grey_area_node *entry = (grey_area_node *) xmalloc (sizeof (grey_area_node));
   entry->base = base;
@@ -1739,7 +1739,7 @@ _gst_print_grey_list (mst_Boolean check_pointers)
 {
   grey_area_node *node;
   OOP *pOOP, oop;
-  int i, n;
+  size_t i, n;
 
   for (n = 0, node = _gst_mem.grey_pages.head; node; node = node->next, n++)
     {
@@ -1776,7 +1776,7 @@ scan_grey_pages ()
 {
   grey_area_node *node, **next, *last;
   OOP *pOOP, oop;
-  int i, n;
+  size_t i, n;
 
 #if defined (MMAN_DEBUG_OUTPUT)
   printf ("Pages on the grey list:\n");

--- a/libgst/oop.c
+++ b/libgst/oop.c
@@ -426,11 +426,12 @@ void _gst_update_object_memory_oop (OOP oop)
 void
 _gst_init_oop_table (PTR address, size_t size)
 {
-  int i;
+  size_t i;
 
   oop_heap = NULL;
-  for (i = MAX_OOP_TABLE_SIZE; i && !oop_heap; i >>= 1)
+  for (i = MAX_OOP_TABLE_SIZE; i && !oop_heap; i >>= 1) {
     oop_heap = _gst_heap_create (address, i * sizeof (struct oop_s));
+  }
 
   if (!oop_heap)
     nomemory (true);
@@ -496,8 +497,7 @@ _gst_realloc_oop_table (size_t newSize)
     return (true);
 
   if (!_gst_heap_sbrk (oop_heap, bytes))
-    {
-      /* try to recover.  Note that we cannot move the OOP table like
+    { /* try to recover.  Note that we cannot move the OOP table like
          we do with the object data.  */
       nomemory (false);
       return (false);

--- a/libgst/oop.c
+++ b/libgst/oop.c
@@ -197,7 +197,7 @@ static void scan_grey_objects ();
 static void scan_grey_pages ();
 
 /* Greys a page worth of pointers starting at BASE.  */
-static void add_to_grey_list (OOP *base, size_t n);
+static void add_to_grey_list (OOP *base, int n);
 
 /* Greys the object OOP.  */
 static void add_grey_object (OOP oop);
@@ -872,23 +872,23 @@ oldspace_before_freeing (heap_data *h, heap_block *blk, size_t sz)
   
   /* Remove related entries from the remembered table.  */
   for (last = NULL, next = &_gst_mem.grey_pages.head; (node = *next); )
-  {
-    if (node->base >= (OOP *)blk && node->base + node->n <= (OOP *)( ((char *)blk) + sz))
-    {
+    if (node->base >= (OOP *)blk
+	&& node->base + node->n <= (OOP *)( ((char *)blk) + sz))
+      {
 #ifdef MMAN_DEBUG_OUTPUT
-	    printf ("  Remembered table entry removed %p..%p\n", node->base, node->base+node->n);
+	printf ("  Remembered table entry removed %p..%p\n",
+		node->base, node->base+node->n);
 #endif
   
-      _gst_mem.rememberedTableEntries--;
-	    *next = node->next;
-	    xfree (node);
-    }
+        _gst_mem.rememberedTableEntries--;
+	*next = node->next;
+	xfree (node);
+      }
     else
-    {
-      last = node;
-	    next = &(node->next);
-    }
-  }
+      {
+        last = node;
+	next = &(node->next);
+      }
 
   _gst_mem.grey_pages.tail = last;
   _gst_mem_protect ((PTR) blk, sz, PROT_READ | PROT_WRITE);
@@ -1055,10 +1055,10 @@ _gst_global_compact ()
 }
 
 void
-_gst_global_gc (size_t next_allocation)
+_gst_global_gc (int next_allocation)
 {
   const char *s;
-  size_t old_limit;
+  int old_limit;
 
   _gst_mem.numGlobalGCs++;
 
@@ -1126,7 +1126,6 @@ _gst_global_gc (size_t next_allocation)
 	  if (target_limit < old_limit)
             {
               s = "done, heap compacted";
-
               compact (0);
               grow_memory_no_compact (target_limit);
             }
@@ -1145,7 +1144,6 @@ _gst_global_gc (size_t next_allocation)
 	       * 100.0 /_gst_mem.grow_threshold_percent;
 
           s = "done, heap grown";
-
           grow_memory_no_compact (MAX (grow_amount_to_satisfy_rate,
 				       grow_amount_to_satisfy_threshold));
         }
@@ -1637,7 +1635,7 @@ add_grey_object (OOP oop)
 }
 
 void
-add_to_grey_list (OOP *base, size_t n)
+add_to_grey_list (OOP *base, int n)
 {
   grey_area_node *entry = (grey_area_node *) xmalloc (sizeof (grey_area_node));
   entry->base = base;
@@ -1778,7 +1776,7 @@ scan_grey_pages ()
 {
   grey_area_node *node, **next, *last;
   OOP *pOOP, oop;
-  size_t i, n;
+  int i, n;
 
 #if defined (MMAN_DEBUG_OUTPUT)
   printf ("Pages on the grey list:\n");

--- a/libgst/oop.c
+++ b/libgst/oop.c
@@ -197,7 +197,7 @@ static void scan_grey_objects ();
 static void scan_grey_pages ();
 
 /* Greys a page worth of pointers starting at BASE.  */
-static void add_to_grey_list (OOP *base, int n);
+static void add_to_grey_list (OOP *base, size_t n);
 
 /* Greys the object OOP.  */
 static void add_grey_object (OOP oop);
@@ -872,23 +872,23 @@ oldspace_before_freeing (heap_data *h, heap_block *blk, size_t sz)
   
   /* Remove related entries from the remembered table.  */
   for (last = NULL, next = &_gst_mem.grey_pages.head; (node = *next); )
-    if (node->base >= (OOP *)blk
-	&& node->base + node->n <= (OOP *)( ((char *)blk) + sz))
-      {
+  {
+    if (node->base >= (OOP *)blk && node->base + node->n <= (OOP *)( ((char *)blk) + sz))
+    {
 #ifdef MMAN_DEBUG_OUTPUT
-	printf ("  Remembered table entry removed %p..%p\n",
-		node->base, node->base+node->n);
+	    printf ("  Remembered table entry removed %p..%p\n", node->base, node->base+node->n);
 #endif
   
-        _gst_mem.rememberedTableEntries--;
-	*next = node->next;
-	xfree (node);
-      }
+      _gst_mem.rememberedTableEntries--;
+	    *next = node->next;
+	    xfree (node);
+    }
     else
-      {
-        last = node;
-	next = &(node->next);
-      }
+    {
+      last = node;
+	    next = &(node->next);
+    }
+  }
 
   _gst_mem.grey_pages.tail = last;
   _gst_mem_protect ((PTR) blk, sz, PROT_READ | PROT_WRITE);
@@ -1055,10 +1055,10 @@ _gst_global_compact ()
 }
 
 void
-_gst_global_gc (int next_allocation)
+_gst_global_gc (size_t next_allocation)
 {
   const char *s;
-  int old_limit;
+  size_t old_limit;
 
   _gst_mem.numGlobalGCs++;
 
@@ -1126,6 +1126,7 @@ _gst_global_gc (int next_allocation)
 	  if (target_limit < old_limit)
             {
               s = "done, heap compacted";
+
               compact (0);
               grow_memory_no_compact (target_limit);
             }
@@ -1144,6 +1145,7 @@ _gst_global_gc (int next_allocation)
 	       * 100.0 /_gst_mem.grow_threshold_percent;
 
           s = "done, heap grown";
+
           grow_memory_no_compact (MAX (grow_amount_to_satisfy_rate,
 				       grow_amount_to_satisfy_threshold));
         }
@@ -1635,7 +1637,7 @@ add_grey_object (OOP oop)
 }
 
 void
-add_to_grey_list (OOP *base, int n)
+add_to_grey_list (OOP *base, size_t n)
 {
   grey_area_node *entry = (grey_area_node *) xmalloc (sizeof (grey_area_node));
   entry->base = base;
@@ -1776,7 +1778,7 @@ scan_grey_pages ()
 {
   grey_area_node *node, **next, *last;
   OOP *pOOP, oop;
-  int i, n;
+  size_t i, n;
 
 #if defined (MMAN_DEBUG_OUTPUT)
   printf ("Pages on the grey list:\n");

--- a/libgst/oop.h
+++ b/libgst/oop.h
@@ -76,7 +76,14 @@
    True, False, and UndefinedObject (nil) oops, which are
    built-ins.  */
 #define INITIAL_OOP_TABLE_SIZE	(1024 * 128 + BUILTIN_OBJECT_BASE)
-#define MAX_OOP_TABLE_SIZE	(1 << 23)
+
+#if SIZEOF_OOP == 4
+  #define MAX_OOP_TABLE_SIZE	(1 << 23)
+#endif
+
+#if SIZEOF_OOP == 8
+  #define MAX_OOP_TABLE_SIZE	(1UL << 36)
+#endif
 
 /* The number of free OOPs under which we trigger GCs.  0 is not
    enough because _gst_scavenge might still need some oops in
@@ -205,7 +212,7 @@ struct memory_space
 
   /* The number of OOPs in the free list and in the full OOP
      table.  num_free_oops is only correct after a GC!  */
-  int num_free_oops, ot_size;
+  size_t num_free_oops, ot_size;
 
   /* The root set of the scavenger.  This includes pages in oldspace that
      were written to, and objects that had to be tenured before they were

--- a/libgst/oop.h
+++ b/libgst/oop.h
@@ -173,7 +173,7 @@ typedef struct surv_space {
 typedef struct grey_area_node {
   struct grey_area_node *next;
   OOP *base;
-  int n;
+  size_t n;
   OOP oop;
 } grey_area_node;
 

--- a/libgst/oop.h
+++ b/libgst/oop.h
@@ -173,7 +173,7 @@ typedef struct surv_space {
 typedef struct grey_area_node {
   struct grey_area_node *next;
   OOP *base;
-  size_t n;
+  int n;
   OOP oop;
 } grey_area_node;
 
@@ -305,7 +305,7 @@ extern void _gst_scavenge (void)
    sweeper to sweep unreachable objects.  Decide whether the heap should
    be compacted or even grown, so that allocating NEXT_ALLOCATION bytes
    leaves it empty enough.  */
-extern void _gst_global_gc (size_t next_allocation)
+extern void _gst_global_gc (int next_allocation) 
   ATTRIBUTE_HIDDEN;
 
 /* Mark, sweep & compact the old objects.  */

--- a/libgst/oop.h
+++ b/libgst/oop.h
@@ -173,7 +173,7 @@ typedef struct surv_space {
 typedef struct grey_area_node {
   struct grey_area_node *next;
   OOP *base;
-  int n;
+  size_t n;
   OOP oop;
 } grey_area_node;
 
@@ -305,7 +305,7 @@ extern void _gst_scavenge (void)
    sweeper to sweep unreachable objects.  Decide whether the heap should
    be compacted or even grown, so that allocating NEXT_ALLOCATION bytes
    leaves it empty enough.  */
-extern void _gst_global_gc (int next_allocation) 
+extern void _gst_global_gc (size_t next_allocation)
   ATTRIBUTE_HIDDEN;
 
 /* Mark, sweep & compact the old objects.  */

--- a/unsupported/torture.st
+++ b/unsupported/torture.st
@@ -12,7 +12,7 @@
 
 a := 1024 * 1024 * 40.
 
-d := Dictionary new.
+d := Array new: a.
 1 to: a do: [ :i |
     d at: i put: Object new.
     (i \\ 1000) = 0 ifTrue: [ i printNl ]

--- a/unsupported/torture.st
+++ b/unsupported/torture.st
@@ -10,10 +10,10 @@
  slots. I put a=74,000 just to leave some margin. With IdentityDictionaries,
  I got a up to 130,000 (because they don't chew up OOPs for the associations)."
 
-a := 100000.
+a := 1024 * 1024 * 40.
 
 d := Dictionary new.
 1 to: a do: [ :i |
-    d at: i put: 'a little test ', i printString.
-    (i \\ 100) = 0 ifTrue: [ i printNl ]
+    d at: i put: Object new.
+    (i \\ 1000) = 0 ifTrue: [ i printNl ]
 ]!


### PR DESCRIPTION
Improve the forward object table allocation in 64 bits.
Corrects some type issues by moving from int to size_t