### PR TITLE
separate object identity from object address

### DIFF
--- a/libgst/Makefile.am
+++ b/libgst/Makefile.am
@@ -25,7 +25,7 @@ libgst_la_SOURCES = \
        save.c      cint.c    	 heap.c	        input.c      \
        sysdep.c    callin.c      mpz.c        \
        print.c	   alloc.c	 re.c	        interp.c     \
-       real.c	   sockets.c	 events.c
+       real.c	   sockets.c	 events.c object_pointer.c
 
 dist_noinst_DATA = valgrind.supp builtins.gperf
 
@@ -38,7 +38,8 @@ noinst_HEADERS = \
 	dict.inl interp.inl interp-bc.inl \
 	sockets.h comp.inl input.h events.h \
 	print.h alloc.h gst-parse.h prims.inl \
-	superop1.inl superop2.inl \
+	superop1.inl superop2.inl object_pointer.h \
+	forward_object.h \
 	sysdep/common/files.c sysdep/common/time.c sysdep/cygwin/files.c \
 	sysdep/cygwin/findexec.c sysdep/cygwin/mem.c sysdep/cygwin/signals.c \
 	sysdep/cygwin/time.c sysdep/cygwin/timer.c sysdep/posix/files.c \

--- a/libgst/dict.c
+++ b/libgst/dict.c
@@ -1348,7 +1348,8 @@ static int find_key_or_nil(OOP dictionaryOOP, OOP keyOOP) {
   dictionary = (gst_object)OOP_TO_OBJ(dictionaryOOP);
   numFixedFields = OOP_FIXED_FIELDS(dictionaryOOP);
   numFields = NUM_WORDS(dictionary) - numFixedFields;
-  index = scramble(OOP_INDEX(keyOOP));
+  OBJ_UPDATE_IDENTITY(OOP_TO_OBJ(keyOOP));
+  index = scramble(TO_INT(OBJ_IDENTITY(OOP_TO_OBJ(keyOOP))));
   count = numFields;
 
   for (; count; count--) {
@@ -1450,7 +1451,8 @@ ssize_t identity_dictionary_find_key(OOP identityDictionaryOOP, OOP keyOOP) {
   numFixedFields = OOP_FIXED_FIELDS(identityDictionaryOOP);
 
   numFields = NUM_WORDS(identityDictionary) - numFixedFields;
-  index = scramble(OOP_INDEX(keyOOP)) * 2;
+  OBJ_UPDATE_IDENTITY(OOP_TO_OBJ(keyOOP));
+  index = scramble(TO_INT(OBJ_IDENTITY(OOP_TO_OBJ(keyOOP)))) * 2;
   count = numFields / 2;
   /* printf ("%d %d %O\n", count, index & numFields - 1, keyOOP); */
   while (count--) {
@@ -1481,7 +1483,8 @@ size_t identity_dictionary_find_key_or_nil(OOP identityDictionaryOOP,
   numFixedFields = OOP_FIXED_FIELDS(identityDictionaryOOP);
 
   numFields = NUM_WORDS(identityDictionary) - numFixedFields;
-  index = scramble(OOP_INDEX(keyOOP)) * 2;
+  OBJ_UPDATE_IDENTITY(OOP_TO_OBJ(keyOOP));
+  index = scramble(TO_INT(OBJ_IDENTITY(OOP_TO_OBJ(keyOOP)))) * 2;
   count = numFields / 2;
   /* printf ("%d %d %O\n", count, index & numFields - 1, keyOOP); */
   while (count--) {

--- a/libgst/dict.inl
+++ b/libgst/dict.inl
@@ -697,7 +697,8 @@ OOP dictionary_association_at(OOP dictionaryOOP, OOP keyOOP) {
   dictionary = OOP_TO_OBJ(dictionaryOOP);
   numFixedFields = OOP_FIXED_FIELDS(dictionaryOOP);
   numFields = NUM_WORDS(dictionary) - numFixedFields;
-  index = scramble(OOP_INDEX(keyOOP));
+  OBJ_UPDATE_IDENTITY(OOP_TO_OBJ(keyOOP));
+  index = scramble(TO_INT(OBJ_IDENTITY(OOP_TO_OBJ(keyOOP))));
   count = numFields;
 
   while (count--) {

--- a/libgst/gst.h
+++ b/libgst/gst.h
@@ -92,8 +92,9 @@ typedef enum {
 /* The header of all objects in the system.
    Note how structural inheritance is achieved without adding extra levels of 
    nested structures.  */
-#define OBJ_HEADER \
-  OOP		objSize;   \
+#define OBJ_HEADER   \
+  OOP		objSize;     \
+  OOP   objIdentity; \
   OOP		objClass
 
 
@@ -106,7 +107,7 @@ gst_object_header;
 
 #define OBJ_HEADER_SIZE_WORDS	(sizeof(gst_object_header) / sizeof(PTR))
 
-_Static_assert(OBJ_HEADER_SIZE_WORDS == 2, "Be carrefull when adding new fields in the header take care of context copy and allocation!");
+_Static_assert(OBJ_HEADER_SIZE_WORDS == 3, "Be carrefull when adding new fields in the header take care of context copy and allocation!");
 
 /* A bare-knuckles accessor for real objects */
 struct object_s

--- a/libgst/interp.c
+++ b/libgst/interp.c
@@ -761,6 +761,7 @@ gst_object alloc_stack_context(int size) {
     cur_chunk_begin += size;
     if COMMON (cur_chunk_begin < cur_chunk_end) {
       OBJ_SET_SIZE(newContext, FROM_INT(size));
+      OBJ_SET_IDENTITY (newContext, FROM_INT(0));
       return (newContext);
     }
 

--- a/libgst/object_pointer.c
+++ b/libgst/object_pointer.c
@@ -1,0 +1,3 @@
+#include "gstpriv.h"
+
+intptr_t _gst_object_identity = TO_INT(0);

--- a/libgst/object_pointer.h
+++ b/libgst/object_pointer.h
@@ -11,6 +11,14 @@
     (obj)->objSize = (valueOOP);                                               \
   } while (0)
 
+#define OBJ_IDENTITY(obj) ((obj)->objIdentity)
+
+#define OBJ_SET_IDENTITY(obj, valueOOP)                                        \
+  do {                                                                         \
+    (obj)->objIdentity = (valueOOP);                                           \
+  } while (0)
+
+
 #define OBJ_CLASS(obj) ((obj)->objClass)
 
 #define OBJ_SET_CLASS(obj, valueOOP)                                           \

--- a/libgst/object_pointer.h
+++ b/libgst/object_pointer.h
@@ -1,6 +1,8 @@
 #ifndef GST_OBJECT_POINTER_H
 #define GST_OBJECT_POINTER_H
 
+extern intptr_t _gst_object_identity;
+
 #define OBJ_ARRAY_AT(obj, n) (((OOP *)((gst_object)obj)->data)[(n)-1])
 #define OBJ_STRING_AT(obj, n) (((char *)((gst_object)obj)->data)[(n)-1])
 
@@ -16,6 +18,14 @@
 #define OBJ_SET_IDENTITY(obj, valueOOP)                                        \
   do {                                                                         \
     (obj)->objIdentity = (valueOOP);                                           \
+  } while (0)
+
+#define OBJ_UPDATE_IDENTITY(obj)                                               \
+  do {                                                                         \
+    if (TO_INT((obj)->objIdentity) == 0) {                                     \
+      _gst_object_identity++;                                                  \
+      (obj)->objIdentity = FROM_INT(_gst_object_identity);                     \
+    }                                                                          \
   } while (0)
 
 

--- a/libgst/oop.c
+++ b/libgst/oop.c
@@ -695,7 +695,7 @@ gst_object _gst_alloc_obj(size_t size, OOP *p_oop) {
   _gst_mem.eden.allocPtr = newAllocPtr;
   *p_oop = alloc_oop(p_instance, _gst_mem.active_flag);
   OBJ_SET_SIZE (p_instance, FROM_INT(BYTES_TO_SIZE(size)));
-
+  OBJ_SET_IDENTITY (p_instance, FROM_INT(0));
   return p_instance;
 }
 
@@ -725,6 +725,7 @@ gst_object alloc_fixed_obj(size_t size, OOP *p_oop) {
 ok:
   *p_oop = alloc_oop(p_instance, F_OLD | F_FIXED);
   OBJ_SET_SIZE (p_instance, FROM_INT(BYTES_TO_SIZE(size)));
+  OBJ_SET_IDENTITY (p_instance, FROM_INT(0));
   return p_instance;
 }
 
@@ -747,6 +748,7 @@ gst_object _gst_alloc_words(size_t size) {
   p_instance = (gst_object)_gst_mem.eden.allocPtr;
   _gst_mem.eden.allocPtr = newAllocPtr;
   OBJ_SET_SIZE (p_instance, FROM_INT(size));
+  OBJ_SET_IDENTITY (p_instance, FROM_INT(0));
   return p_instance;
 }
 

--- a/libgst/oop.c
+++ b/libgst/oop.c
@@ -588,6 +588,7 @@ void _gst_make_oop_weak(OOP oop) {
 void _gst_swap_objects(OOP oop1, OOP oop2) {
   struct oop_s tempOOP;
   inc_ptr incPtr;
+  OOP tempId;
 
   incPtr = INC_SAVE_POINTER();
   INC_ADD_OOP(oop1);
@@ -608,6 +609,10 @@ void _gst_swap_objects(OOP oop1, OOP oop2) {
   tempOOP = *oop2; /* note structure assignment going on here */
   *oop2 = *oop1;
   *oop1 = tempOOP;
+
+  tempId = OBJ_IDENTITY(OOP_TO_OBJ(oop1));
+  OBJ_SET_IDENTITY(OOP_TO_OBJ(oop1), OBJ_IDENTITY(OOP_TO_OBJ(oop2)));
+  OBJ_SET_IDENTITY(OOP_TO_OBJ(oop2), tempId);
 
   /* If the incremental GC has reached oop1 but not oop2 (or vice versa),
      this flag will end up in the wrong OOP, i.e. in the one that has already

--- a/libgst/prims.inl
+++ b/libgst/prims.inl
@@ -2164,7 +2164,12 @@ static intptr_t VMpr_Object_hash(int id, volatile int numArgs) {
 
   oop1 = POP_OOP();
   if COMMON (IS_OOP(oop1)) {
-    PUSH_INT(OOP_INDEX(oop1));
+    gst_object object;
+
+    object = OOP_TO_OBJ(oop1);
+    OBJ_UPDATE_IDENTITY(object);
+    PUSH_OOP(OBJ_IDENTITY(object));
+
     PRIM_SUCCEEDED;
   }
   UNPOP(1);

--- a/libgst/save.c
+++ b/libgst/save.c
@@ -108,6 +108,7 @@ typedef struct save_file_header {
   size_t grow_threshold_percent;
   size_t space_grow_rate;
   size_t num_free_oops;
+  intptr_t object_identity;
   intptr_t ot_base;
   intptr_t prim_table_md5[16 / sizeof(intptr_t)]; /* checksum for the primitive
                                                      table */
@@ -395,6 +396,7 @@ void save_file_version(int imageFd, struct save_file_header *headerp) {
   headerp->edenSpaceSize = _gst_mem.eden.totalSize;
   headerp->survSpaceSize = _gst_mem.surv[0].totalSize;
   headerp->oldSpaceSize = _gst_mem.old->heap_limit;
+  headerp->object_identity = _gst_object_identity;
 
   headerp->big_object_threshold = _gst_mem.big_object_threshold;
   headerp->grow_threshold_percent = _gst_mem.grow_threshold_percent;
@@ -437,6 +439,8 @@ mst_Boolean load_snapshot(int imageFd) {
 #ifdef SNAPSHOT_TRACE
   printf("After loading header: %lld\n", file_pos + buf_pos);
 #endif /* SNAPSHOT_TRACE */
+
+  _gst_object_identity = header.object_identity;
 
   _gst_init_mem(header.edenSpaceSize, header.survSpaceSize,
                 header.oldSpaceSize * 3, header.big_object_threshold,

--- a/tests/objects.ok
+++ b/tests/objects.ok
@@ -50,3 +50,8 @@ true
 125
 124
 returned value is 124
+
+Execution begins...
+true
+true
+returned value is true

--- a/tests/objects.st
+++ b/tests/objects.st
@@ -194,3 +194,13 @@ Eval [
   (ro instVarAt: 2) printNl.
 ]
 
+Eval [
+  | id1 id2 o1 o2 |
+  o1 := Object new.
+  o2 := Object new.
+  id1 := o1 identityHash.
+  id2 := o2 identityHash.
+  o1 become: o2.
+  (id1 = o1 identityHash) printNl.
+  (id2 = o2 identityHash) printNl.
+]


### PR DESCRIPTION
Extend object format with the identity of the object:

- value set only when needed
- change the image format and save the last object id in the header
- when object swapping preserve the identity
- add test case
